### PR TITLE
Add MeowMiner v0.1.0: Pearl (PRL) pool miner for sm_89, validated vs reference verifier

### DIFF
--- a/meowminer/.github-workflows/build.yml
+++ b/meowminer/.github-workflows/build.yml
@@ -1,0 +1,53 @@
+# CI for the Meowcoin-Foundation/MeowMiner repo.
+# NOTE: this file lives at .github-workflows/build.yml in the handoff tree;
+# rename the directory to .github/workflows/ when moving into the MeowMiner repo
+# (kept out of .github/ here so it does not run inside meowcoin-status).
+name: Build MeowMiner
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.12" }
+      - run: pip install -e . pytest torch --index-url https://pypi.org/simple
+      - run: pytest tests/ -q
+
+  bundle:
+    # Self-contained rig bundle: meowminer wheel + pearl_mining manylinux wheel
+    # + install.sh. The rigs' miner-downloader.sh fetches this from releases.
+    runs-on: ubuntu-24.04
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.12" }
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Build meowminer wheel
+        run: pip install build && python -m build --wheel -o dist/
+      - name: Build pearl_mining wheel
+        run: |
+          git clone --depth 1 https://github.com/pearl-research-labs/pearl /tmp/pearl
+          pip install maturin
+          maturin build --release -m /tmp/pearl/py-pearl-mining/Cargo.toml -o dist/
+      - name: Assemble bundle
+        run: |
+          mkdir bundle && cp dist/*.whl bundle/
+          cp packaging/install.sh bundle/
+          tar czf meowminer-bundle.tar.gz -C bundle .
+      - uses: actions/upload-artifact@v4
+        with:
+          name: meowminer-bundle
+          path: meowminer-bundle.tar.gz
+      - name: Attach to release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: meowminer-bundle.tar.gz

--- a/meowminer/.gitignore
+++ b/meowminer/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.pytest_cache/

--- a/meowminer/HANDOFF.md
+++ b/meowminer/HANDOFF.md
@@ -1,0 +1,148 @@
+# HANDOFF — Beat SRBMiner poolside on herominers (Pearl PRL, 4070 Ti Super)
+
+**For:** the Claude session running on the desktop next to CatStack/Mfarm
+(this work was done in a cloud sandbox that cannot reach the rigs — see
+"Environment constraints" at the bottom).
+
+**Mission:** poolside hashrate on herominers for the 4070 Ti Super rigs,
+mining Pearl (PRL), higher than SRBMiner-Multi achieves on the same cards.
+
+---
+
+## 1. Where things stand
+
+* `Meowcoin-Foundation/MeowMiner` existed as an **empty repo** with only the
+  description "Pearl (PRL) sm_89-optimized GPU miner, no dev fee". This
+  directory (`meowminer/`) is its initial implementation — **move it there**
+  (`git subtree` or plain copy), rename `.github-workflows/` →
+  `.github/workflows/`, and tag `v0.1.0` so CI publishes the rig bundle that
+  `mfarm`'s miner-downloader expects.
+* Everything that can be validated without a GPU **is validated**: 16 tests
+  pass (target math, pattern partitioning, jackpot folding bit-exact vs a
+  scalar port of zk-pow's `try_mine_one`, stratum client against an
+  in-process pool speaking the P2Pearl object dialect) — including the gold
+  standard, `tests/test_cross_engine.py`: **shares mined by both engines are
+  accepted by the actual Rust reference verifier** (`verify_plain_proof`).
+  Consensus-critical semantics (noise determinism, commitment seed chain,
+  Merkle/chunk layout, jackpot folding, bincode wire format) are confirmed
+  correct, not just believed correct.
+* `pearl_mining` (PyO3 bindings from pearl-research-labs/pearl) builds clean
+  with maturin on Python 3.12; MeowMiner uses it for share packaging and
+  pre-submit verification, so wire-format bugs are structurally impossible.
+
+## 2. The competitive landscape (verified 2026-06-09)
+
+| Miner | sm_89 hashrate | Fee | Notes |
+|---|---|---|---|
+| SRBMiner-Multi ≥3.3.1 (`--algorithm pearlhash`) | ~baseline | **3.00%** | the one to beat; poolside loses the fee on top of kernel quality |
+| alpha-miner 1.7.7 | 4070: 65–70 TH/s, 4080S: 155–165 TH/s → 4070 TiS ≈ 115–130 TH/s | undocumented | binary-only; `--pool` accepts any stratum, marketed for AlphaPool |
+| Pearl reference vLLM miner | n/a | 0 | **sm_90 only** (H100/H200) — why this niche exists |
+| MeowMiner v0 (torch engine) | ~5–15 TH/s expected (CPU-hash-bound) | 0 | correctness vehicle; v1 kernel work is the win condition |
+
+## 3. Pearlhash, the 60-second version (all file refs = pearl monorepo)
+
+1. Job: pool sends a 76-byte incomplete header + 256-bit share `target`
+   (`mining.notify {job_id, header, target, height}`; P2Pearl
+   `stratum/server.py:87-95`). No nonce — the search space is the random
+   int7 A (m×k) and B (k×n) matrices.
+2. `job_key = blake3(header || mining_config)`; commitment seeds chain
+   `hash_b → b_noise_seed → a_noise_seed` (`zk-pow/src/ffi/mine.rs:163-186`).
+3. Deterministic low-rank noise (rank 128) is added to A/B
+   (`miner/miner-base/.../noise_generation.py`, vendored bit-exact in
+   `src/meowminer/vendor/`).
+4. GEMM with per-rank-block cumulative tiles; each (rows_pattern ×
+   cols_pattern) partition XOR-folds its cumulative tile into a 16×u32
+   jackpot with rotl-13 mixing (`mine.rs:78-117`,
+   `pearl_program.rs: JACKPOT_SIZE=16, LROT_PER_TILE=13`).
+5. `hash_jackpot = blake3(jackpot_le_bytes, key=a_noise_seed)`; share iff
+   `U256_LE(hash_jackpot) <= nbits_to_difficulty(target_to_bits(target)) * h*w*k`.
+   **The h\*w\*k (~2^19–2^20) verifier adjustment is the classic landmine** —
+   grade at the raw notify target and you throw away ~all your shares
+   (`zk-pow/src/api/sanity_checks.rs:86-102`, P2Pearl `pow/verify.py`).
+6. Submit `mining.submit {job_id, plain_proof: base64(bincode(PlainProof)), hs}`
+   — Merkle-authenticated strips of the *unnoised* A/B rows (137–370 KB).
+   Pools verify CPU-side with `verify_plain_proof_with_nbits`; no ZK proof
+   for shares (only for found blocks, gateway-side).
+
+The "hashrate" everyone quotes = MACs/s against graded jackpots
+(= m·n·k per attempt when patterns exactly cover the matrices), which is why
+4070 Ti Super (~353 dense int8 TOPS) tops out near ~150 TH/s.
+
+## 4. The plan to win, in order
+
+### Step 0 — pin the live network constants (30 min, desktop)
+`MiningConfiguration` (k=common_dim, rank, patterns) is consensus data not
+carried by stratum. Confirm against a synced pearld
+(`getblocktemplate` carries it) or by asking in the Pearl discord, then pin
+via `meowminer --config-bytes <52-byte-hex>` in the flight sheet and a
+constant in `netconfig.py`. Also confirm the herominers PRL stratum port
+(this sandbox couldn't load their site). Verifier-enforced constraints
+confirmed against pearl_mining: `k >= 16*rank`, tile `h*w >= 32`, network
+MMAType = `Int7xInt7ToInt32`.
+
+### Step 1 — first light on a 4070 Ti Super (hours)
+```
+pip install -e meowminer[gpu]; pip install pearl_mining-*.whl
+meowminer --pool stratum+tcp://pearl.herominers.com:<port> --wallet prl1p... \
+          --worker bench1 --engine torch --log-level DEBUG
+```
+The built-in pre-submit `verify_plain_proof_with_nbits` check means: if shares
+pass locally and the pool still rejects, the dialect needs a tweak (capture
+SRBMiner's traffic with `socat -v` as ground truth); if they fail locally,
+the engine has a bug — `tests/test_cross_engine.py` is the harness to extend
+(compare torch engine vs `engines/cpu.py` on the same RNG seed).
+
+### Step 2 — A/B against SRBMiner via Mfarm (1 day)
+`mfarm-integration/FLIGHT-SHEET.md` has the exact commands: half the 4070 TiS
+group on MeowMiner, half on SRBMiner, same wallet, 24h, compare per-worker
+poolside averages on herominers. This is the metric the user cares about.
+
+### Step 3 — v1 kernel work: move the hashing onto the GPU (the actual win)
+v0's ceiling is the CPU blake3 of the A/B commitment (the GEMM:hash byte
+ratio is m·n/(m+n) — you cannot out-batch it). The reference already has GPU
+kernels for everything needed:
+
+* `miner/pearl-gemm/csrc/blake3/blake3.cu` — portable CUDA blake3 (~209 lines).
+* `miner/pearl-gemm/csrc/tensor_hash/` — chunked Merkle/commitment pipeline
+  (~2k lines; entangled with cute/cutlass *types* but not with WGMMA — the
+  compute is hash arithmetic, port to plain CUDA or build with
+  `-gencode arch=compute_89,code=sm_89`).
+* Keep the GEMM itself on cuBLASLt int8 (`torch._int_mm`) — on Ada it reaches
+  80%+ of peak TOPS for 4096-class shapes, which already clears alpha-miner's
+  published numbers; the full CUTLASS sm_89 NoisyGEMM port
+  (`kernel_traits.hpp` TMA/WGMMA → cp.async/mma.sync) is optional polish.
+* Wire them behind the `hasher` seam in `engines/torch_int8.py` (the seam is
+  already there), JIT via `torch.utils.cpp_extension.load` on rigs with nvcc
+  or prebuild in CI.
+
+Target after step 3: ≥130 TH/s poolside per 4070 Ti Super, vs SRBMiner's
+baseline minus its 3% fee.
+
+### Step 4 — publish + farm rollout
+Tag MeowMiner `v0.2.0`; CI bundles wheels; `mfarm deploy` + flight-sheet flip
+moves the whole 4070 TiS group. Keep one SRBMiner rig as a control.
+
+## 5. Map of this directory
+
+```
+meowminer/
+  src/meowminer/         the package (stratum, targets, algo, engines, proofs, cli)
+  src/meowminer/vendor/  bit-exact vendored noise generator (ISC, pearl)
+  tests/                 all green on CPU-only machines
+  mfarm-integration/     CatStack patch + flight sheets + A/B protocol
+  packaging/install.sh   rig-side bundle installer (used by miner-downloader)
+  .github-workflows/     CI for the MeowMiner repo (rename to .github/workflows)
+  HANDOFF.md             this file
+```
+
+## 6. Environment constraints that shaped this session
+
+Cloud sandbox: GitHub+PyPI only (every other domain, SSH, and the user's LAN
+blocked — verified with curl, headless Chromium, and raw TCP). CatStack's
+dashboard lives on the desktop at localhost:8888 and the rigs are LAN-side,
+so deployment and GPU benchmarking are physically impossible from here; hence
+this handoff. Wallet (herominers/pearlhash notes from self-sent emails):
+the AlphaPool one is `prl1pja266dfa7kcg0xdagaacy0y7x60h7qrw3tcau4enx4gwnmmyxxvs7ep7ad`,
+the Pearlhash-pool one is `prl1p6zlg6r00gv3tqhauc3esz3mx8fdzuypn6w6plywx98x4ntfaraqs9pmvr6`
+— confirm which one herominers payouts should go to before creating flight
+sheets.

--- a/meowminer/README.md
+++ b/meowminer/README.md
@@ -1,0 +1,57 @@
+# MeowMiner
+
+**Pearl (PRL) pool miner for NVIDIA GPUs. No dev fee.**
+
+Pearl's proof-of-useful-work is verifiable int8 matrix multiplication
+("pearlhash"): every mining attempt draws random A (m×k) / B (k×n) matrices,
+adds deterministic header-bound noise, runs the GEMM on tensor cores while
+XOR-folding cumulative tiles into a 64-byte *jackpot* transcript, and
+blake3-hashes that transcript against the pool's share target. MeowMiner is a
+clean-room pool client over the Pearl reference primitives
+([pearl-research-labs/pearl](https://github.com/pearl-research-labs/pearl),
+ISC), aimed at consumer Ada cards (sm_89: 4070/4070 Ti Super/4080) that the
+reference vLLM miner (sm_90 only) does not support — and at the 3.00% dev fee
+that SRBMiner charges for the same algorithm.
+
+## Status
+
+| Component | State |
+|---|---|
+| Stratum (herominers/luckypool "object" dialect + alphapool positional) | implemented, unit-tested |
+| Target/bound math incl. the `h*w*k` verifier adjustment | implemented, unit-tested |
+| Jackpot pipeline (noise, commitment chain, XOR/rotl folding) | implemented, bit-exact vs a scalar port of the Rust reference, unit-tested |
+| Share packaging + pre-submit local verification | implemented via `pearl_mining` (PyO3) |
+| CPU reference engine | working; **shares accepted by the Rust reference verifier** |
+| GPU engine v0 (`torch._int_mm` tensor-core GEMM, GPU folding) | **shares accepted by the Rust reference verifier** (CPU device); needs its first perf run on a real GPU |
+| GPU engine v1 (CUDA blake3/tensor-hash on-device, sm_89 build) | planned — see `HANDOFF.md`; this is what overtakes SRBMiner |
+
+## Install (rig)
+
+```bash
+pip install meowminer[gpu]
+# plus the pearl_mining wheel, built once from the Pearl monorepo:
+#   cd pearl/py-pearl-mining && maturin build --release
+pip install pearl_mining-*.whl
+```
+
+## Run
+
+```bash
+meowminer --pool stratum+tcp://pearl.herominers.com:<PORT> \
+          --wallet prl1p<...> --worker rig1 \
+          --engine torch --device cuda
+```
+
+Every share is verified locally with the reference verifier
+(`verify_plain_proof_with_nbits`) before submission; a correctness bug shows
+up as a loud local error, never as silent pool rejects.
+
+## Farm deployment
+
+See `mfarm-integration/` for the CatStack (Mfarm) registry patch, the
+herominers flight sheets, and the SRBMiner A/B test procedure.
+
+## License
+
+ISC. Vendored reference code from pearl-research-labs/pearl is ISC; see
+`src/meowminer/vendor/PEARL-LICENSE`.

--- a/meowminer/mfarm-integration/FLIGHT-SHEET.md
+++ b/meowminer/mfarm-integration/FLIGHT-SHEET.md
@@ -1,0 +1,65 @@
+# Deploying MeowMiner on the farm through Mfarm (CatStack)
+
+Apply `catstack-meowminer.patch` to the CatStack checkout first
+(`git apply mfarm-integration/catstack-meowminer.patch`), reinstall
+(`pip install -e .`), then:
+
+## 1. Flight sheets — herominers PRL
+
+```bash
+# MeowMiner on the 4070 Ti Super group
+mfarm flight create prl-herominers-meowminer \
+  --coin PRL --algo pearlhash --miner meowminer \
+  --pool stratum+tcp://pearl.herominers.com:1225 \
+  --wallet prl1p<YOUR_WALLET> \
+  --worker %HOSTNAME% \
+  --extra-args "--engine torch --device cuda --matrix-m 4096 --matrix-n 4096"
+
+# SRBMiner baseline on the SAME pool/wallet for the A/B comparison
+mfarm flight create prl-herominers-srb \
+  --coin PRL --algo pearlhash --miner srbminer \
+  --pool stratum+tcp://pearl.herominers.com:1225 \
+  --wallet prl1p<YOUR_WALLET> \
+  --worker %HOSTNAME%-srb \
+  --extra-args "--disable-cpu"
+```
+
+Check the actual herominers PRL stratum port on https://pearl.herominers.com
+before creating the sheets (1225 is a placeholder — this sandbox could not
+reach the site to confirm). Use the high-difficulty port for >4 GPU rigs if
+they offer one.
+
+## 2. Overclocks for 4070 Ti Super on pearlhash
+
+pearlhash is tensor-core int8 GEMM: core-clock and cache bound, only mildly
+memory bound (operands are reused k times). Suggested starting profile:
+
+```bash
+mfarm oc create prl-4070tis --power-limit 270 --core-offset 150 --mem-offset 0 --fan 70
+mfarm oc apply prl-4070tis group:4070tis
+```
+
+Then sweep power limit 240→285 W while watching poolside hashrate; pearlhash
+typically keeps >95% hashrate down to ~80% TDP. Memory offset buys ~nothing;
+leave it stock for stability.
+
+## 3. The A/B test that settles "beat SRBMiner"
+
+Split identical rigs into two halves for 24h (PPLNS smoothing window matters,
+don't compare 10-minute spot values):
+
+```bash
+mfarm flight apply prl-herominers-meowminer group:4070tis-a
+mfarm flight apply prl-herominers-srb       group:4070tis-b
+```
+
+Compare on the herominers dashboard per worker name (`rigN` vs `rigN-srb`):
+*poolside average hashrate over 24h* and *accepted share count*. Remember
+SRBMiner's pearlhash carries a 3.00% dev fee that shows up poolside as ~3%
+missing shares; MeowMiner has none.
+
+## 4. Watchdog
+
+`mfarm-agent` restarts the miner on crash/zero-hashrate via the standard
+wrapper; meowminer logs `... TH/s | A:n R:n S:n` lines that the agent's
+`meowminer_log` parser picks up.

--- a/meowminer/mfarm-integration/catstack-meowminer.patch
+++ b/meowminer/mfarm-integration/catstack-meowminer.patch
@@ -1,0 +1,65 @@
+diff --git a/mfarm/miners/registry.py b/mfarm/miners/registry.py
+index f9a4df2..8f67c7a 100644
+--- a/mfarm/miners/registry.py
++++ b/mfarm/miners/registry.py
+@@ -167,6 +167,7 @@ _register(MinerDefinition(
+         "ghostrider", "dynamo", "yespower",
+         "verthash", "heavyhash", "karlsenhash",
+         "pyrinhash", "sha512_256d_radiant",
++        "pearlhash",
+     ],
+     gpu_type="any",
+     api_type="srbminer_http",
+@@ -175,6 +176,21 @@ _register(MinerDefinition(
+ ))
+ 
+ 
++_register(MinerDefinition(
++    name="meowminer",
++    display_name="MeowMiner (Pearl PRL, no dev fee)",
++    # Python entry point installed by the meowminer wheel; the wrapper invokes
++    # it as `meowminer --pool ... --wallet ... --worker ...`.
++    binary_name="meowminer/meowminer",
++    supported_algos=["pearlhash"],
++    gpu_type="nvidia",
++    # No HTTP/TCP API yet -- the agent parses /var/log/mfarm/miner.log
++    # ("X.XX TH/s | A:n R:n S:n" lines from meowminer's stats logger).
++    api_type="meowminer_log",
++    default_api_port=0,
++    supports_solo=False,
++))
++
+ def get_miner(name: str) -> MinerDefinition | None:
+     return MINERS.get(name.lower())
+ 
+diff --git a/mfarm/worker/miner-downloader.sh b/mfarm/worker/miner-downloader.sh
+index 56ab885..2f6495b 100644
+--- a/mfarm/worker/miner-downloader.sh
++++ b/mfarm/worker/miner-downloader.sh
+@@ -74,6 +74,26 @@ download "srbminer" \
+     "https://github.com/doktor83/SRBMiner-Multi/releases/download/2.8.3/SRBMiner-Multi-2-8-3-Linux.tar.xz" \
+     "SRBMiner-Multi"
+ 
++
++# MeowMiner (NVIDIA, Pearl PRL) -- self-contained pyz + pearl_mining wheel from
++# the MeowMiner releases page. Installed as a directory, not a single binary.
++install_meowminer() {
++    if [ "$TARGET" != "all" ] && [ "$TARGET" != "meowminer" ]; then return; fi
++    echo "  Installing meowminer..."
++    mkdir -p "$DEST/meowminer"
++    cd /tmp && rm -rf dl-meowminer && mkdir dl-meowminer && cd dl-meowminer
++    wget -q "https://github.com/Meowcoin-Foundation/MeowMiner/releases/latest/download/meowminer-bundle.tar.gz" -O bundle.tgz \
++        || { echo "  FAILED: meowminer bundle download"; return; }
++    tar xzf bundle.tgz
++    # bundle layout: install.sh creates a venv under $DEST/meowminer/venv,
++    # installs the wheels (meowminer, pearl_mining, torch), and links
++    # $DEST/meowminer/meowminer to venv/bin/meowminer.
++    bash install.sh "$DEST/meowminer" || { echo "  FAILED: meowminer install"; return; }
++    echo "  OK: $DEST/meowminer/meowminer"
++    cd /tmp && rm -rf dl-meowminer
++}
++install_meowminer
++
+ echo ""
+ echo "=== Installed miners ==="
+ ls -lh "$DEST/"

--- a/meowminer/packaging/install.sh
+++ b/meowminer/packaging/install.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Rig-side installer invoked by mfarm's miner-downloader.sh with the install
+# dir as $1 (default /opt/mfarm/miners/meowminer). Expects the bundle's wheels
+# alongside this script.
+set -euo pipefail
+
+DEST="${1:-/opt/mfarm/miners/meowminer}"
+HERE="$(cd "$(dirname "$0")" && pwd)"
+
+mkdir -p "$DEST"
+python3 -m venv "$DEST/venv"
+"$DEST/venv/bin/pip" install --upgrade pip -q
+# torch from PyPI (CUDA build); pinned major to avoid surprise ABI bumps
+"$DEST/venv/bin/pip" install -q "torch>=2.2,<3" numpy blake3
+"$DEST/venv/bin/pip" install -q "$HERE"/*.whl
+ln -sf "$DEST/venv/bin/meowminer" "$DEST/meowminer"
+
+echo "meowminer installed: $("$DEST/meowminer" --version)"

--- a/meowminer/pyproject.toml
+++ b/meowminer/pyproject.toml
@@ -1,0 +1,28 @@
+[build-system]
+requires = ["setuptools>=68.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "meowminer"
+version = "0.1.0"
+description = "MeowMiner - Pearl (PRL) pool miner for NVIDIA GPUs, no dev fee"
+requires-python = ">=3.10"
+license = { text = "ISC" }
+dependencies = [
+    "numpy>=1.26",
+    "blake3>=0.4",
+]
+
+[project.optional-dependencies]
+# The GPU engine and the (vendored) reference noise generator need torch.
+gpu = ["torch>=2.2"]
+# Share packaging needs the pearl_mining PyO3 wheel built from
+# pearl-research-labs/pearl/py-pearl-mining (maturin build --release).
+dev = ["pytest>=8.0", "ruff"]
+
+[project.scripts]
+meowminer = "meowminer.cli:main"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+include = ["meowminer*"]

--- a/meowminer/src/meowminer/__init__.py
+++ b/meowminer/src/meowminer/__init__.py
@@ -1,0 +1,3 @@
+"""MeowMiner — Pearl (PRL) pool miner for NVIDIA GPUs. No dev fee."""
+
+__version__ = "0.1.0"

--- a/meowminer/src/meowminer/__main__.py
+++ b/meowminer/src/meowminer/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/meowminer/src/meowminer/algo.py
+++ b/meowminer/src/meowminer/algo.py
@@ -1,0 +1,228 @@
+"""Pearlhash algorithm primitives, mirrored from pearl-research-labs/pearl.
+
+Sources of truth (file references are into the Pearl monorepo):
+  * job key / commitment seeds: zk-pow/src/ffi/mine.rs::{compute_job_key,
+    compute_commitment_hash}
+  * jackpot accumulation:        zk-pow/src/ffi/mine.rs::try_mine_one and
+    zk-pow/src/circuit/pearl_program.rs (JACKPOT_SIZE=16, LROT_PER_TILE=13)
+  * jackpot hash:                zk-pow/src/api/proof_utils.rs::compute_jackpot_hash
+  * periodic patterns:           zk-pow/src/api/proof_utils.rs (PeriodicPattern)
+
+Everything here is CPU/numpy and serves two roles: the reference engine (slow
+but correct, used for tests and share validation before submit) and the shared
+plumbing for the GPU engine (which reproduces the same numbers with tensor-core
+GEMMs).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+from blake3 import blake3
+
+JACKPOT_SIZE = 16
+LROT_PER_TILE = 13
+BLAKE3_CHUNK_LEN = 1024
+SIGNAL_MIN, SIGNAL_MAX = -64, 64
+
+
+# ── periodic patterns ────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class PeriodicPattern:
+    """Generalized arithmetic progression: {a*s0 + b*s1 + c*s2}."""
+
+    shape: tuple[tuple[int, int], ...]  # 3 x (stride, length)
+
+    def to_list(self) -> list[int]:
+        res = [0]
+        for stride, length in self.shape:
+            res = [r + i * stride for i in range(length) for r in res]
+        return res
+
+    @property
+    def period(self) -> int:
+        stride, length = self.shape[-1]
+        return stride * length
+
+    @property
+    def size(self) -> int:
+        out = 1
+        for _, length in self.shape:
+            out *= length
+        return out
+
+    def offset_is_valid(self, offset: int) -> bool:
+        for stride, length in reversed(self.shape):
+            offset %= stride * length
+            if offset >= stride:
+                return False
+        return True
+
+    def partitions(self, total_dimension: int) -> list[list[int]]:
+        """All index groups for one matrix dimension (mine.rs::threads_partition)."""
+        if total_dimension % self.period != 0:
+            raise ValueError("total_dimension must be divisible by pattern period")
+        base = self.to_list()
+        return [
+            [offset + d for d in base]
+            for offset in range(total_dimension)
+            if self.offset_is_valid(offset)
+        ]
+
+    def valid_offsets(self, total_dimension: int) -> list[int]:
+        return [o for o in range(total_dimension) if self.offset_is_valid(o)]
+
+
+@dataclass(frozen=True)
+class MiningConfig:
+    """Python mirror of pearl_mining.MiningConfiguration for the hot path.
+
+    ``to_bytes`` must produce the exact 52-byte serialization used in
+    job_key = blake3(header || config); we delegate that to the PyO3 binding at
+    runtime (see proofs.py) and carry the raw bytes here so the hot path has no
+    native dependency.
+    """
+
+    common_dim: int  # k
+    rank: int
+    rows_pattern: PeriodicPattern
+    cols_pattern: PeriodicPattern
+    config_bytes: bytes  # exact 52-byte serialization from pearl_mining
+
+    @property
+    def tile_h(self) -> int:
+        return self.rows_pattern.size
+
+    @property
+    def tile_w(self) -> int:
+        return self.cols_pattern.size
+
+    @property
+    def dot_product_length(self) -> int:
+        return self.common_dim - self.common_dim % self.rank
+
+    @property
+    def difficulty_adjustment(self) -> int:
+        return self.tile_h * self.tile_w * self.dot_product_length
+
+
+# ── hashing / seeds ──────────────────────────────────────────────────────────
+
+
+def pad_to_chunk_boundary(data: bytes) -> bytes:
+    rem = len(data) % BLAKE3_CHUNK_LEN
+    return data if rem == 0 else data + b"\x00" * (BLAKE3_CHUNK_LEN - rem)
+
+
+def compute_job_key(header_bytes: bytes, config_bytes: bytes) -> bytes:
+    return blake3(header_bytes + config_bytes).digest()
+
+
+def compute_commitment_seeds(
+    job_key: bytes, a_row_major: bytes, b_col_major: bytes
+) -> tuple[bytes, bytes]:
+    """Return (b_noise_seed, a_noise_seed) — mine.rs::compute_commitment_hash.
+
+    Inputs must already be chunk-padded; the hashes double as the matrices'
+    Merkle roots, which is what binds the noise to the committed matrices.
+    """
+    hash_a = blake3(a_row_major, key=job_key).digest()
+    hash_b = blake3(b_col_major, key=job_key).digest()
+    b_noise_seed = blake3(job_key + hash_b).digest()
+    a_noise_seed = blake3(b_noise_seed + hash_a).digest()
+    return b_noise_seed, a_noise_seed
+
+
+def compute_jackpot_hash(jackpot: np.ndarray, a_noise_seed: bytes) -> bytes:
+    """blake3 of the 16xu32 jackpot (LE bytes), keyed with a_noise_seed."""
+    assert jackpot.dtype == np.uint32 and jackpot.size == JACKPOT_SIZE
+    return blake3(jackpot.astype("<u4").tobytes(), key=a_noise_seed).digest()
+
+
+# ── noise ────────────────────────────────────────────────────────────────────
+
+
+def dense_noise(a_noise_seed: bytes, b_noise_seed: bytes, m: int, k: int, n: int, rank: int):
+    """Dense (m x k) A-noise and (k x n) B-noise via the low-rank factors.
+
+    Wraps the vendored reference NoiseGenerator (bit-identical to pearl's
+    miner-base). Returns int16 numpy arrays (entries fit in [-63, 63]).
+    """
+    import torch
+
+    from meowminer.vendor.noise_generation import NoiseGenerator
+
+    gen = NoiseGenerator(noise_rank=rank, noise_range=128)
+    a_l, a_r, b_l, b_r = gen.generate_noise_metrices(a_noise_seed, b_noise_seed, m, k, n)
+    noise_a = (a_l.to(torch.int32) @ a_r.to(torch.int32)).numpy()
+    noise_b = (b_l.to(torch.int32) @ b_r.to(torch.int32)).numpy()
+    return noise_a.astype(np.int16), noise_b.astype(np.int16)
+
+
+# ── jackpot accumulation (reference) ─────────────────────────────────────────
+
+
+def jackpots_for_attempt(
+    a_noised: np.ndarray,  # (m, k) int32
+    bt_noised: np.ndarray,  # (n, k) int32  (B^T rows = B cols)
+    config: MiningConfig,
+) -> tuple[np.ndarray, list[tuple[list[int], list[int]]]]:
+    """Compute the 16xu32 jackpot for every (a_rows, b_cols) partition pair.
+
+    Returns (jackpots, partitions) where jackpots has shape
+    (num_row_parts * num_col_parts, 16) uint32 and partitions[i] is the
+    (a_rows, b_cols) index lists that produced jackpots[i].
+
+    Vectorized restatement of the scalar loop in mine.rs::try_mine_one: for
+    each rank-block ``ll`` the *cumulative* tile C_cum = A_sel @ B_sel^T over
+    columns [0, ll) is XOR-folded to one u32 and rotl-mixed into
+    jackpot[(ll/rank - 1) % 16].
+    """
+    m, k = a_noised.shape
+    n, _ = bt_noised.shape
+    rank = config.rank
+    row_parts = config.rows_pattern.partitions(m)
+    col_parts = config.cols_pattern.partitions(n)
+    h, w = config.tile_h, config.tile_w
+    num_blocks = config.dot_product_length // rank
+
+    # Gather: (R, h, k) and (C, w, k)
+    a_sel = a_noised[np.asarray(row_parts)]  # (R, h, k)
+    b_sel = bt_noised[np.asarray(col_parts)]  # (C, w, k)
+
+    jackpots = np.zeros((len(row_parts), len(col_parts), JACKPOT_SIZE), dtype=np.uint32)
+    # cumulative tiles: (R, C, h, w) int32 with wrapping arithmetic
+    cum = np.zeros((len(row_parts), len(col_parts), h, w), dtype=np.int64)
+
+    for blk in range(num_blocks):
+        lo, hi = blk * rank, (blk + 1) * rank
+        # (R, h, rank) x (C, w, rank) -> (R, C, h, w)
+        part = np.einsum(
+            "rhx,cwx->rchw",
+            a_sel[:, :, lo:hi].astype(np.int64),
+            b_sel[:, :, lo:hi].astype(np.int64),
+        )
+        cum += part
+        tiles_u32 = (cum & 0xFFFFFFFF).astype(np.uint32)  # i32 wrap -> u32 view
+        xored = np.bitwise_xor.reduce(tiles_u32.reshape(len(row_parts), len(col_parts), -1), axis=2)
+        tid = blk % JACKPOT_SIZE
+        j = jackpots[:, :, tid]
+        jackpots[:, :, tid] = ((j << LROT_PER_TILE) | (j >> (32 - LROT_PER_TILE))) ^ xored
+
+    parts = [(r, c) for r in row_parts for c in col_parts]
+    return jackpots.reshape(-1, JACKPOT_SIZE), parts
+
+
+def grade_jackpots(
+    jackpots: np.ndarray, a_noise_seed: bytes, bound: int
+) -> list[tuple[int, bytes]]:
+    """Hash every jackpot and return [(index, hash_jackpot)] entries <= bound."""
+    hits = []
+    for i in range(jackpots.shape[0]):
+        h = compute_jackpot_hash(jackpots[i], a_noise_seed)
+        if int.from_bytes(h, "little") <= bound:
+            hits.append((i, h))
+    return hits

--- a/meowminer/src/meowminer/cli.py
+++ b/meowminer/src/meowminer/cli.py
@@ -1,0 +1,82 @@
+"""meowminer CLI.
+
+Example (herominers):
+    meowminer --pool stratum+tcp://pearl.herominers.com:1225 \
+              --wallet prl1p... --worker rig1 --engine torch --device cuda:0
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import sys
+from urllib.parse import urlparse
+
+from . import __version__
+from .miner import Miner
+from .netconfig import load_config
+from .stratum import StratumClient
+
+
+def parse_pool(pool: str) -> tuple[str, int]:
+    if "//" not in pool:
+        pool = "stratum+tcp://" + pool
+    u = urlparse(pool)
+    if not u.hostname or not u.port:
+        raise SystemExit(f"--pool must be host:port or stratum+tcp://host:port (got {pool!r})")
+    return u.hostname, u.port
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="meowminer", description="MeowMiner — Pearl (PRL) pool miner, no dev fee")
+    p.add_argument("--pool", required=True, help="stratum endpoint, e.g. stratum+tcp://pearl.herominers.com:1225")
+    p.add_argument("--wallet", required=True, help="PRL wallet address (prl1...)")
+    p.add_argument("--worker", default="meowminer", help="worker name shown on the pool")
+    p.add_argument("--engine", choices=["torch", "cpu"], default="torch")
+    p.add_argument("--device", default="cuda", help="torch device for the GPU engine (cuda, cuda:1, ...)")
+    p.add_argument("--matrix-m", type=int, default=4096, help="rows of A per attempt")
+    p.add_argument("--matrix-n", type=int, default=4096, help="cols of B per attempt")
+    p.add_argument("--dialect", choices=["object", "positional"], default="object",
+                   help="stratum dialect: object = herominers/luckypool, positional = alphapool")
+    p.add_argument("--config-bytes", default=None,
+                   help="hex of the 52-byte network MiningConfiguration (default: pearl_mining default)")
+    p.add_argument("--no-presubmit-verify", action="store_true",
+                   help="skip local verify_plain_proof before submitting (not recommended)")
+    p.add_argument("--log-level", default="INFO")
+    p.add_argument("--version", action="version", version=f"meowminer {__version__}")
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    logging.basicConfig(
+        level=args.log_level.upper(),
+        format="%(asctime)s %(levelname).1s %(name)s: %(message)s",
+        datefmt="%H:%M:%S",
+    )
+    host, port = parse_pool(args.pool)
+    config = load_config(args.config_bytes)
+
+    if args.engine == "torch":
+        from .engines.torch_int8 import TorchInt8Engine
+
+        engine = TorchInt8Engine(device=args.device, m=args.matrix_m, n=args.matrix_n)
+    else:
+        from .engines.cpu import CpuEngine
+
+        engine = CpuEngine()
+    engine.configure(config, args.matrix_m, args.matrix_n)
+
+    client = StratumClient(host, port, wallet=args.wallet, worker=args.worker,
+                           agent=f"meowminer/{__version__}", dialect=args.dialect)
+    miner = Miner(client, engine, config, presubmit_verify=not args.no_presubmit_verify)
+    try:
+        asyncio.run(miner.run())
+    except KeyboardInterrupt:
+        logging.getLogger("meowminer").info("interrupted; shutting down")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/meowminer/src/meowminer/engines/base.py
+++ b/meowminer/src/meowminer/engines/base.py
@@ -1,0 +1,51 @@
+"""Engine interface: turn a Job into share hits as fast as the silicon allows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterator, Protocol
+
+import numpy as np
+
+from ..algo import MiningConfig
+from ..job import Job
+
+
+@dataclass
+class Hit:
+    """One candidate that cleared the share bound.
+
+    Carries everything proofs.build_plain_proof needs: the *unnoised* matrices
+    (the proof commits to them), the winning partition's row/col indices, and
+    the jackpot hash for logging / block-bound checking.
+    """
+
+    job: Job
+    a_matrix: np.ndarray  # (m, k) int8, raw signal
+    bt_matrix: np.ndarray  # (n, k) int8, raw B^T
+    a_rows: list[int]
+    b_cols: list[int]
+    hash_jackpot: bytes
+    is_block: bool = False
+
+
+@dataclass
+class AttemptStats:
+    attempts: int = 0  # (A,B) pairs tried
+    partitions: int = 0  # jackpot candidates graded
+    macs: int = 0  # multiply-accumulates executed (hashrate basis)
+
+
+class Engine(Protocol):
+    name: str
+
+    def configure(self, config: MiningConfig, m: int, n: int) -> None: ...
+
+    def mine(self, job: Job, share_bound: int, block_bound: int) -> Iterator[tuple[list[Hit], AttemptStats]]:
+        """Yield (hits, stats) batches until the caller stops iterating.
+
+        Implementations must re-check ``job`` freshness only via the caller
+        (the orchestrator swaps jobs by tearing down the iterator), keeping
+        engines free of synchronization concerns.
+        """
+        ...

--- a/meowminer/src/meowminer/engines/cpu.py
+++ b/meowminer/src/meowminer/engines/cpu.py
@@ -1,0 +1,74 @@
+"""Reference CPU engine: bit-exact, slow, used for tests and sanity checks."""
+
+from __future__ import annotations
+
+from typing import Iterator
+
+import numpy as np
+
+from ..algo import (
+    MiningConfig,
+    SIGNAL_MAX,
+    SIGNAL_MIN,
+    compute_commitment_seeds,
+    compute_job_key,
+    dense_noise,
+    grade_jackpots,
+    jackpots_for_attempt,
+    pad_to_chunk_boundary,
+)
+from ..job import Job
+from .base import AttemptStats, Hit
+
+
+class CpuEngine:
+    name = "cpu-reference"
+
+    def __init__(self, seed: int | None = None) -> None:
+        self._rng = np.random.default_rng(seed)
+        self._config: MiningConfig | None = None
+        self._m = self._n = 0
+
+    def configure(self, config: MiningConfig, m: int, n: int) -> None:
+        if m % config.rows_pattern.period or n % config.cols_pattern.period:
+            raise ValueError("m / n must be divisible by the pattern periods")
+        if config.common_dim % config.rank:
+            raise ValueError("common_dim must be a multiple of rank")
+        self._config, self._m, self._n = config, m, n
+
+    def mine(self, job: Job, share_bound: int, block_bound: int) -> Iterator[tuple[list[Hit], AttemptStats]]:
+        assert self._config is not None, "configure() first"
+        cfg, m, n, k = self._config, self._m, self._n, self._config.common_dim
+        job_key = compute_job_key(job.header, cfg.config_bytes)
+
+        while True:
+            a = self._rng.integers(SIGNAL_MIN, SIGNAL_MAX + 1, size=(m, k), dtype=np.int8)
+            bt = self._rng.integers(SIGNAL_MIN, SIGNAL_MAX + 1, size=(n, k), dtype=np.int8)
+
+            a_bytes = pad_to_chunk_boundary(a.astype(np.uint8).tobytes())
+            bt_bytes = pad_to_chunk_boundary(bt.astype(np.uint8).tobytes())
+            b_seed, a_seed = compute_commitment_seeds(job_key, a_bytes, bt_bytes)
+
+            noise_a, noise_b = dense_noise(a_seed, b_seed, m, k, n, cfg.rank)
+            a_noised = a.astype(np.int32) + noise_a.astype(np.int32)
+            bt_noised = bt.astype(np.int32) + noise_b.T.astype(np.int32)
+
+            jackpots, parts = jackpots_for_attempt(a_noised, bt_noised, cfg)
+            hits = [
+                Hit(
+                    job=job,
+                    a_matrix=a,
+                    bt_matrix=bt,
+                    a_rows=parts[i][0],
+                    b_cols=parts[i][1],
+                    hash_jackpot=h,
+                    is_block=int.from_bytes(h, "little") <= block_bound,
+                )
+                for i, h in grade_jackpots(jackpots, a_seed, share_bound)
+            ]
+            stats = AttemptStats(
+                attempts=1,
+                partitions=len(parts),
+                macs=len(parts) * cfg.difficulty_adjustment,
+            )
+            yield hits, stats

--- a/meowminer/src/meowminer/engines/torch_int8.py
+++ b/meowminer/src/meowminer/engines/torch_int8.py
@@ -1,0 +1,187 @@
+"""GPU engine v0: tensor-core int8 GEMM via torch, GPU jackpot folding.
+
+What runs where:
+  * signal generation, noising, slice GEMMs (torch._int_mm -> cuBLASLt IMMA),
+    cumulative-tile XOR folding and rotl mixing: GPU
+  * matrix commitment (keyed blake3 over chunk-padded A/B bytes) and the
+    per-partition 64-byte jackpot hashes: CPU (the `blake3` wheel, rayon
+    multithreaded)
+
+The CPU hashing is the known bottleneck of v0 (see HANDOFF.md): the design
+keeps a pluggable ``hasher`` seam so the phase-2 CUDA extension (vendored
+pearl-gemm tensor_hash kernels built for sm_89) drops in without touching the
+GEMM loop. Expect single-digit TH/s from v0; the kernel work is what takes it
+past SRBMiner.
+
+Correctness is the non-negotiable part: every step mirrors
+zk-pow/src/ffi/mine.rs and is cross-checked against the numpy reference in
+tests/test_cross_engine.py.
+"""
+
+from __future__ import annotations
+
+import logging
+from concurrent.futures import ThreadPoolExecutor
+from typing import Iterator
+
+import numpy as np
+from blake3 import blake3
+
+from ..algo import (
+    JACKPOT_SIZE,
+    LROT_PER_TILE,
+    MiningConfig,
+    SIGNAL_MAX,
+    SIGNAL_MIN,
+    compute_commitment_seeds,
+    compute_job_key,
+    pad_to_chunk_boundary,
+)
+from ..job import Job
+from .base import AttemptStats, Hit
+
+log = logging.getLogger("meowminer.engine.torch")
+
+
+class TorchInt8Engine:
+    name = "torch-int8"
+
+    def __init__(self, device: str = "cuda", m: int = 4096, n: int = 4096, hash_workers: int = 8) -> None:
+        import torch  # deferred so CPU-only installs can import the package
+
+        self.torch = torch
+        self.device = torch.device(device)
+        self._m, self._n = m, n
+        self._cfg: MiningConfig | None = None
+        self._pool = ThreadPoolExecutor(max_workers=hash_workers, thread_name_prefix="jackpot-hash")
+
+    # -- setup ---------------------------------------------------------------
+
+    def configure(self, config: MiningConfig, m: int | None = None, n: int | None = None) -> None:
+        torch = self.torch
+        if m:
+            self._m = m
+        if n:
+            self._n = n
+        if self._m % config.rows_pattern.period or self._n % config.cols_pattern.period:
+            raise ValueError("m / n must be divisible by the pattern periods")
+        if config.common_dim % config.rank:
+            raise ValueError("common_dim must be a multiple of rank")
+        self._cfg = config
+
+        row_parts = config.rows_pattern.partitions(self._m)
+        col_parts = config.cols_pattern.partitions(self._n)
+        self._row_parts, self._col_parts = row_parts, col_parts
+        # Stacked gather indices: selected rows laid out partition-major so the
+        # GEMM output is directly viewable as (R, h, C, w) tiles.
+        self._row_idx = torch.tensor([i for p in row_parts for i in p], device=self.device, dtype=torch.long)
+        self._col_idx = torch.tensor([i for p in col_parts for i in p], device=self.device, dtype=torch.long)
+        log.info(
+            "configured %s: m=%d n=%d k=%d rank=%d tiles=%dx%d partitions=%d",
+            self.name, self._m, self._n, config.common_dim, config.rank,
+            config.tile_h, config.tile_w, len(row_parts) * len(col_parts),
+        )
+
+    # -- hot loop ------------------------------------------------------------
+
+    def mine(self, job: Job, share_bound: int, block_bound: int) -> Iterator[tuple[list[Hit], AttemptStats]]:
+        assert self._cfg is not None, "configure() first"
+        torch, cfg = self.torch, self._cfg
+        m, n, k, rank = self._m, self._n, cfg.common_dim, cfg.rank
+        h, w = cfg.tile_h, cfg.tile_w
+        R, C = len(self._row_parts), len(self._col_parts)
+        num_blocks = cfg.dot_product_length // rank
+        job_key = compute_job_key(job.header, cfg.config_bytes)
+
+        gen = torch.Generator(device=self.device)
+
+        while True:
+            # 1. draw signal int7-safe in [-64, 64] (reference range; +noise fits int8)
+            a8 = torch.randint(SIGNAL_MIN, SIGNAL_MAX + 1, (m, k), dtype=torch.int8, device=self.device, generator=gen)
+            bt8 = torch.randint(SIGNAL_MIN, SIGNAL_MAX + 1, (n, k), dtype=torch.int8, device=self.device, generator=gen)
+
+            # 2. commitment seeds (CPU blake3 over the exact committed bytes)
+            a_np = a8.cpu().numpy()
+            bt_np = bt8.cpu().numpy()
+            a_bytes = pad_to_chunk_boundary(a_np.astype(np.uint8).tobytes())
+            bt_bytes = pad_to_chunk_boundary(bt_np.astype(np.uint8).tobytes())
+            b_seed, a_seed = compute_commitment_seeds(job_key, a_bytes, bt_bytes)
+
+            # 3. deterministic noise (reference generator), applied on GPU
+            from ..vendor.noise_generation import NoiseGenerator
+
+            ng = NoiseGenerator(noise_rank=rank, noise_range=128)
+            a_l, a_r, b_l, b_r = ng.generate_noise_metrices(a_seed, b_seed, m, k, n)
+            noise_a = (a_l.to(self.device, torch.int32) @ a_r.to(self.device, torch.int32))
+            noise_bt = (b_l.to(self.device, torch.int32) @ b_r.to(self.device, torch.int32)).T.contiguous()
+            a_noised = (a8.to(torch.int32) + noise_a).to(torch.int8)
+            bt_noised = (bt8.to(torch.int32) + noise_bt).to(torch.int8)
+
+            # 4. gather partition-major stacked operands
+            a_sel = a_noised.index_select(0, self._row_idx)  # (R*h, k)
+            bt_sel = bt_noised.index_select(0, self._col_idx)  # (C*w, k)
+
+            # 5. rank-block cumulative GEMM + XOR/rotl folding, all on GPU
+            jack = torch.zeros(R, C, JACKPOT_SIZE, dtype=torch.int32, device=self.device)
+            cum = torch.zeros(R * h, C * w, dtype=torch.int32, device=self.device)
+            for blk in range(num_blocks):
+                lo, hi = blk * rank, (blk + 1) * rank
+                cum += torch._int_mm(a_sel[:, lo:hi].contiguous(), bt_sel[:, lo:hi].T.contiguous())
+                tiles = cum.view(R, h, C, w)
+                xored = tiles.permute(0, 2, 1, 3).reshape(R, C, h * w)
+                xored = _xor_reduce_last(xored)
+                tid = blk % JACKPOT_SIZE
+                j = jack[:, :, tid]
+                jack[:, :, tid] = _rotl32(j, LROT_PER_TILE) ^ xored
+
+            # 6. grade: per-partition keyed blake3 of the 64-byte jackpot (CPU pool)
+            jack_np = jack.cpu().numpy().astype("<i4").view("<u4").reshape(R * C, JACKPOT_SIZE)
+            hits = self._grade(job, a_np, bt_np, jack_np, a_seed, share_bound, block_bound)
+
+            stats = AttemptStats(attempts=1, partitions=R * C, macs=R * C * cfg.difficulty_adjustment)
+            yield hits, stats
+
+    # -- grading -------------------------------------------------------------
+
+    def _grade(self, job, a_np, bt_np, jack_np, a_seed, share_bound, block_bound) -> list[Hit]:
+        def hash_one(i: int) -> tuple[int, bytes]:
+            return i, blake3(jack_np[i].tobytes(), key=a_seed).digest()
+
+        hits = []
+        for i, digest in self._pool.map(hash_one, range(jack_np.shape[0]), chunksize=2048):
+            if int.from_bytes(digest, "little") <= share_bound:
+                r, c = divmod(i, len(self._col_parts))
+                hits.append(
+                    Hit(
+                        job=job,
+                        a_matrix=a_np,
+                        bt_matrix=bt_np,
+                        a_rows=self._row_parts[r],
+                        b_cols=self._col_parts[c],
+                        hash_jackpot=digest,
+                        is_block=int.from_bytes(digest, "little") <= block_bound,
+                    )
+                )
+        return hits
+
+
+def _xor_reduce_last(t):
+    """XOR-reduce the last dimension (zero-pads to a power of two; 0 is the XOR identity)."""
+    size = t.shape[-1]
+    if size & (size - 1):
+        import torch
+
+        pow2 = 1 << size.bit_length()
+        pad = torch.zeros(*t.shape[:-1], pow2 - size, dtype=t.dtype, device=t.device)
+        t = torch.cat([t, pad], dim=-1)
+    while t.shape[-1] > 1:
+        half = t.shape[-1] // 2
+        t = t[..., :half] ^ t[..., half:]
+    return t[..., 0]
+
+
+def _rotl32(t, bits: int):
+    """Logical rotl on int32 tensors (torch >> is arithmetic; mask the fill)."""
+    left = t << bits
+    right = (t >> (32 - bits)) & ((1 << bits) - 1)
+    return left | right

--- a/meowminer/src/meowminer/job.py
+++ b/meowminer/src/meowminer/job.py
@@ -1,0 +1,54 @@
+"""Mining job state derived from ``mining.notify``."""
+
+from __future__ import annotations
+
+import struct
+from dataclasses import dataclass, field
+
+from .targets import block_bound, parse_notify_target, share_bound
+
+HEADER_LEN = 76  # version(4) | prev_block(32) | merkle_root(32) | timestamp(4) | nbits(4)
+
+
+@dataclass(frozen=True)
+class Job:
+    """One unit of pool work (object dialect: herominers / luckypool).
+
+    ``header`` is the 76-byte *incomplete* header exactly as the pool sent it;
+    it feeds ``job_key = blake3(header || mining_config)`` and must never be
+    mutated (the share target is communicated out-of-band, NOT via nbits).
+    """
+
+    job_id: str
+    header: bytes
+    share_target: int  # 256-bit integer from the notify `target` field
+    height: int
+    clean: bool = False
+
+    def __post_init__(self) -> None:
+        if len(self.header) != HEADER_LEN:
+            raise ValueError(f"incomplete header must be {HEADER_LEN} bytes, got {len(self.header)}")
+
+    @classmethod
+    def from_notify(cls, params: dict) -> "Job":
+        return cls(
+            job_id=str(params["job_id"]),
+            header=bytes.fromhex(params["header"]),
+            share_target=parse_notify_target(params["target"]),
+            height=int(params.get("height", 0)),
+            clean=bool(params.get("clean", False)),
+        )
+
+    @property
+    def nbits(self) -> int:
+        return struct.unpack_from("<I", self.header, 72)[0]
+
+    @property
+    def timestamp(self) -> int:
+        return struct.unpack_from("<I", self.header, 68)[0]
+
+    def share_bound(self, tile_h: int, tile_w: int, common_dim: int) -> int:
+        return share_bound(self.share_target, tile_h, tile_w, common_dim)
+
+    def block_bound(self, tile_h: int, tile_w: int, common_dim: int) -> int:
+        return block_bound(self.nbits, tile_h, tile_w, common_dim)

--- a/meowminer/src/meowminer/miner.py
+++ b/meowminer/src/meowminer/miner.py
@@ -1,0 +1,115 @@
+"""Orchestrator: stratum jobs in, engine batches out, shares submitted."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+
+from .algo import MiningConfig, compute_job_key
+from .engines.base import Engine, Hit
+from .job import Job
+from .proofs import build_plain_proof_b64, verify_share_locally
+from .stats import MinerStats
+from .stratum import StratumClient
+from .targets import target_to_bits
+
+log = logging.getLogger("meowminer")
+
+STATS_INTERVAL_S = 30.0
+
+
+class Miner:
+    def __init__(self, client: StratumClient, engine: Engine, config: MiningConfig, presubmit_verify: bool = True) -> None:
+        self.client = client
+        self.engine = engine
+        self.config = config
+        self.presubmit_verify = presubmit_verify
+        self.stats = MinerStats()
+        self._job: Job | None = None
+        self._job_seq = 0  # bumped on every new job; mining thread watches it
+        self._job_lock = threading.Lock()
+        self._stop = False
+
+    # -- lifecycle -------------------------------------------------------------
+
+    async def run(self) -> None:
+        self.client.on_job = self._on_job
+        await self.client.connect()
+        loop = asyncio.get_running_loop()
+        mining = loop.run_in_executor(None, self._mining_thread, loop)
+        stats_task = asyncio.create_task(self._stats_loop())
+        try:
+            await mining
+        finally:
+            self._stop = True
+            stats_task.cancel()
+            await self.client.close()
+
+    async def _on_job(self, job: Job) -> None:
+        with self._job_lock:
+            self._job = job
+            self._job_seq += 1
+
+    async def _stats_loop(self) -> None:
+        while not self._stop:
+            await asyncio.sleep(STATS_INTERVAL_S)
+            log.info("%s", self.stats.summary())
+
+    # -- mining thread ----------------------------------------------------------
+
+    def _mining_thread(self, loop: asyncio.AbstractEventLoop) -> None:
+        import time
+
+        while not self._stop:
+            with self._job_lock:
+                job, seq = self._job, self._job_seq
+            if job is None:
+                time.sleep(0.2)
+                continue
+
+            share_bound = job.share_bound(self.config.tile_h, self.config.tile_w, self.config.dot_product_length)
+            block_bound = job.block_bound(self.config.tile_h, self.config.tile_w, self.config.dot_product_length)
+            log.info(
+                "mining job %s: share_bound=%x... (%d-bit)",
+                job.job_id, share_bound >> 192, share_bound.bit_length(),
+            )
+
+            for hits, stats in self.engine.mine(job, share_bound, block_bound):
+                self.stats.record(stats.macs)
+                for hit in hits:
+                    self._submit(hit, loop)
+                with self._job_lock:
+                    if self._job_seq != seq or self._stop:
+                        break  # job changed: tear down iterator, restart loop
+
+    def _submit(self, hit: Hit, loop: asyncio.AbstractEventLoop) -> None:
+        job_key = compute_job_key(hit.job.header, self.config.config_bytes)
+        try:
+            proof_b64 = build_plain_proof_b64(hit, self.config, job_key)
+        except Exception:
+            log.exception("failed to package share; dropping")
+            return
+
+        if self.presubmit_verify:
+            share_nbits = target_to_bits(hit.job.share_target)
+            ok, msg = verify_share_locally(hit.job.header, proof_b64, share_nbits)
+            if not ok:
+                log.error("local share verification FAILED (%s) — not submitting. "
+                          "This means an engine correctness bug; please report.", msg)
+                return
+
+        if hit.is_block:
+            log.warning("*** BLOCK CANDIDATE *** job=%s hash=%s", hit.job.job_id, hit.hash_jackpot.hex()[:24])
+            self.stats.blocks += 1
+
+        async def do_submit():
+            res = await self.client.submit(hit.job.job_id, proof_b64, hashrate=self.stats.hashrate())
+            if res.accepted:
+                self.stats.accepted += 1
+            elif res.error_code == 21:
+                self.stats.stale += 1
+            else:
+                self.stats.rejected += 1
+
+        asyncio.run_coroutine_threadsafe(do_submit(), loop)

--- a/meowminer/src/meowminer/netconfig.py
+++ b/meowminer/src/meowminer/netconfig.py
@@ -1,0 +1,42 @@
+"""Network MiningConfiguration resolution.
+
+The pool's mining.notify carries only the header; the MiningConfiguration
+(common_dim k, rank, row/col patterns) is a network constant the miner must
+already know — it feeds job_key, the noise, and the difficulty adjustment, so
+a mismatch means 100% rejects.
+
+Resolution order:
+  1. explicit --config-bytes hex on the CLI (52 bytes)
+  2. pearl_mining's default MiningConfiguration (tracks the deployed network)
+
+The desktop session should confirm the live mainnet values once against a
+running pearld (getblocktemplate carries them) and pin them in mfarm's flight
+sheet; see HANDOFF.md.
+"""
+
+from __future__ import annotations
+
+from .algo import MiningConfig, PeriodicPattern
+
+
+def _pattern_from_pm(p) -> PeriodicPattern:
+    shape = tuple((int(s), int(l)) for s, l in p.shape)
+    return PeriodicPattern(shape=shape)
+
+
+def load_config(config_bytes_hex: str | None = None) -> MiningConfig:
+    import pearl_mining as pm
+
+    if config_bytes_hex:
+        raw = bytes.fromhex(config_bytes_hex)
+        cfg = pm.MiningConfiguration.from_bytes(raw)
+    else:
+        cfg = pm.MiningConfiguration.default()
+        raw = bytes(cfg.to_bytes())
+    return MiningConfig(
+        common_dim=int(cfg.common_dim),
+        rank=int(cfg.rank),
+        rows_pattern=_pattern_from_pm(cfg.rows_pattern),
+        cols_pattern=_pattern_from_pm(cfg.cols_pattern),
+        config_bytes=raw,
+    )

--- a/meowminer/src/meowminer/proofs.py
+++ b/meowminer/src/meowminer/proofs.py
@@ -1,0 +1,68 @@
+"""PlainProof packaging via the pearl_mining PyO3 bindings.
+
+The wire format (bincode-serialized PlainProof, base64) and the Merkle tree
+semantics (keyed blake3, 1024-byte chunk leaves, multileaf proofs) come from
+the Pearl repo. We never reimplement them: pearl_mining is built once from
+pearl-research-labs/pearl/py-pearl-mining (``maturin build --release``) and
+provides MerkleTree / MatrixMerkleProof / PlainProof / verify_plain_proof.
+
+Mirrors zk-pow/src/ffi/mine.rs::build_matrix_proof.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .algo import MiningConfig, pad_to_chunk_boundary
+from .engines.base import Hit
+
+
+def _pearl_mining():
+    try:
+        import pearl_mining
+    except ImportError as exc:  # pragma: no cover - environment dependent
+        raise ImportError(
+            "pearl_mining is required to package shares. Build it from the Pearl "
+            "monorepo: cd pearl/py-pearl-mining && maturin build --release, then "
+            "pip install the wheel on every rig."
+        ) from exc
+    return pearl_mining
+
+
+def build_matrix_proof(matrix_i8: np.ndarray, job_key: bytes, row_indices: list[int]):
+    """MatrixMerkleProof over the chunk-padded row-major matrix bytes."""
+    pm = _pearl_mining()
+    rows, cols = matrix_i8.shape
+    padded = pad_to_chunk_boundary(matrix_i8.astype(np.uint8).tobytes())
+    tree = pm.MerkleTree(padded, job_key)
+    leaf_indices = pm.MerkleTree.compute_leaf_indices_from_rows(row_indices, (rows, cols))
+    proof = tree.get_multileaf_proof(leaf_indices)
+    return pm.MatrixMerkleProof(proof, list(row_indices))
+
+
+def build_plain_proof_b64(hit: Hit, config: MiningConfig, job_key: bytes) -> str:
+    """Assemble and serialize the share for mining.submit."""
+    pm = _pearl_mining()
+    m, k = hit.a_matrix.shape
+    n, _ = hit.bt_matrix.shape
+    a_proof = build_matrix_proof(hit.a_matrix, job_key, hit.a_rows)
+    bt_proof = build_matrix_proof(hit.bt_matrix, job_key, hit.b_cols)
+    proof = pm.PlainProof(m, n, k, config.rank, a_proof, bt_proof)
+    return proof.to_base64()
+
+
+def verify_share_locally(header: bytes, proof_b64: str, share_nbits: int) -> tuple[bool, str]:
+    """Pre-submit sanity check, identical to pool-side grading.
+
+    Catching a malformed share locally costs microseconds; a pool-side reject
+    costs the share and (on some pools) ban points.
+    """
+    pm = _pearl_mining()
+    verify = getattr(pm, "verify_plain_proof_with_nbits", None)
+    hdr = pm.IncompleteBlockHeader.from_bytes(header)
+    proof = pm.PlainProof.from_base64(proof_b64)
+    if verify is None:
+        ok, msg = pm.verify_plain_proof(hdr, proof)
+        return bool(ok), f"(block-bound check only; nbits-override binding missing) {msg}"
+    ok, msg = verify(hdr, proof, share_nbits)
+    return bool(ok), str(msg)

--- a/meowminer/src/meowminer/stats.py
+++ b/meowminer/src/meowminer/stats.py
@@ -1,0 +1,53 @@
+"""Hashrate accounting.
+
+Reports the same unit the pools and hashrate.no use for pearlhash: hashes =
+multiply-accumulates executed against graded jackpots (h*w*k per partition),
+i.e. the number the `hs` submit field and poolside estimates are based on.
+"""
+
+from __future__ import annotations
+
+import time
+from collections import deque
+from dataclasses import dataclass, field
+
+
+@dataclass
+class MinerStats:
+    window_s: float = 600.0
+    started: float = field(default_factory=time.monotonic)
+    accepted: int = 0
+    rejected: int = 0
+    stale: int = 0
+    blocks: int = 0
+    _samples: deque = field(default_factory=deque)  # (t, macs)
+    _total_macs: int = 0
+
+    def record(self, macs: int) -> None:
+        now = time.monotonic()
+        self._samples.append((now, macs))
+        self._total_macs += macs
+        cutoff = now - self.window_s
+        while self._samples and self._samples[0][0] < cutoff:
+            self._samples.popleft()
+
+    def hashrate(self) -> float:
+        """Windowed hashes/second."""
+        if not self._samples:
+            return 0.0
+        t0 = self._samples[0][0]
+        elapsed = max(time.monotonic() - t0, 1e-9)
+        return sum(m for _, m in self._samples) / elapsed
+
+    def summary(self) -> str:
+        hr = self.hashrate()
+        unit, scale = "H/s", 1.0
+        for u, s in (("TH/s", 1e12), ("GH/s", 1e9), ("MH/s", 1e6), ("kH/s", 1e3)):
+            if hr >= s:
+                unit, scale = u, s
+                break
+        up = time.monotonic() - self.started
+        return (
+            f"{hr / scale:.2f} {unit} | A:{self.accepted} R:{self.rejected} S:{self.stale}"
+            f"{' | BLOCKS:' + str(self.blocks) if self.blocks else ''} | up {up / 60:.0f}m"
+        )

--- a/meowminer/src/meowminer/stratum.py
+++ b/meowminer/src/meowminer/stratum.py
@@ -1,0 +1,221 @@
+"""Asyncio stratum client for Pearlhash pools.
+
+Speaks the "object" dialect used by herominers / luckypool (the one SRBMiner
+speaks), with the alphapool "positional" dialect as a fallback:
+
+  object:
+    -> mining.authorize {"wallet": "prl1...", "worker": "rig", "agent": "meowminer/x.y"}
+    <- mining.notify    {"job_id", "header", "target", "height"[, "clean"]}
+    -> mining.submit    {"job_id", "plain_proof": "<b64>", "hs": <float>}
+
+  positional (alphapool):
+    -> mining.subscribe ["meowminer/x.y"]
+    -> mining.authorize ["<wallet>.<worker>", "x"]
+    <- mining.notify    [job_id, prev_hash, header, 0, ntime, nbits, clean]
+    -> mining.submit    [worker, job_id, "<b64>"]
+
+Framing: newline-delimited JSON; responses are bare {"id", "result"} with no
+"jsonrpc" member; notifications carry "id": null.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from dataclasses import dataclass
+from typing import Awaitable, Callable
+
+from .job import Job
+
+log = logging.getLogger("meowminer.stratum")
+
+STALE_SHARE_CODE = 21
+LOW_DIFF_CODE = 23
+
+
+@dataclass
+class SubmitResult:
+    accepted: bool
+    error_code: int | None = None
+    message: str = ""
+
+
+class StratumClient:
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        wallet: str,
+        worker: str = "meowminer",
+        agent: str = "meowminer/0.1.0",
+        dialect: str = "object",
+        timeout: float = 30.0,
+    ) -> None:
+        self.host, self.port = host, port
+        self.wallet, self.worker, self.agent = wallet, worker, agent
+        self.dialect = dialect
+        self.timeout = timeout
+        self.on_job: Callable[[Job], Awaitable[None]] | None = None
+        self._reader: asyncio.StreamReader | None = None
+        self._writer: asyncio.StreamWriter | None = None
+        self._pending: dict[int, asyncio.Future] = {}
+        self._next_id = 1
+        self._read_task: asyncio.Task | None = None
+        self.connected = asyncio.Event()
+
+    # -- connection lifecycle -------------------------------------------------
+
+    async def connect(self) -> None:
+        backoff = 1.0
+        while True:
+            try:
+                self._reader, self._writer = await asyncio.wait_for(
+                    asyncio.open_connection(self.host, self.port), self.timeout
+                )
+                break
+            except (OSError, asyncio.TimeoutError) as exc:
+                log.warning("connect to %s:%s failed (%s); retrying in %.0fs", self.host, self.port, exc, backoff)
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2, 60.0)
+        self._read_task = asyncio.create_task(self._read_loop())
+        await self._handshake()
+        self.connected.set()
+        log.info("connected to %s:%s as %s.%s (%s dialect)", self.host, self.port, self.wallet[:14] + "...", self.worker, self.dialect)
+
+    async def close(self) -> None:
+        self.connected.clear()
+        if self._read_task:
+            self._read_task.cancel()
+        if self._writer:
+            self._writer.close()
+
+    async def _handshake(self) -> None:
+        if self.dialect == "positional":
+            await self._call("mining.subscribe", [self.agent])
+            result = await self._call("mining.authorize", [f"{self.wallet}.{self.worker}", "x"])
+        else:
+            result = await self._call(
+                "mining.authorize",
+                {"wallet": self.wallet, "worker": self.worker, "agent": self.agent},
+            )
+        if result is not True and result is not None:
+            log.warning("authorize returned %r (continuing; some pools reply oddly)", result)
+
+    # -- rpc ------------------------------------------------------------------
+
+    async def _send(self, payload: dict) -> None:
+        assert self._writer is not None
+        self._writer.write((json.dumps(payload, separators=(",", ":")) + "\n").encode())
+        await self._writer.drain()
+
+    async def _call(self, method: str, params) -> object:
+        req_id = self._next_id
+        self._next_id += 1
+        fut: asyncio.Future = asyncio.get_running_loop().create_future()
+        self._pending[req_id] = fut
+        await self._send({"id": req_id, "method": method, "params": params})
+        try:
+            return await asyncio.wait_for(fut, self.timeout)
+        finally:
+            self._pending.pop(req_id, None)
+
+    async def _read_loop(self) -> None:
+        assert self._reader is not None
+        try:
+            while True:
+                line = await self._reader.readline()
+                if not line:
+                    raise ConnectionError("pool closed connection")
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    msg = json.loads(line)
+                except json.JSONDecodeError:
+                    log.warning("unparseable line from pool: %r", line[:200])
+                    continue
+                await self._dispatch(msg)
+        except (ConnectionError, asyncio.IncompleteReadError) as exc:
+            log.warning("pool connection lost: %s", exc)
+            self.connected.clear()
+            for fut in self._pending.values():
+                if not fut.done():
+                    fut.set_exception(ConnectionError("disconnected"))
+        except asyncio.CancelledError:
+            pass
+
+    async def _dispatch(self, msg: dict) -> None:
+        if msg.get("method") == "mining.notify":
+            try:
+                job = self._parse_notify(msg.get("params"))
+            except (KeyError, ValueError) as exc:
+                log.error("bad mining.notify: %s (params=%r)", exc, msg.get("params"))
+                return
+            log.info("new job %s height=%s target=%064x clean=%s", job.job_id, job.height, job.share_target, job.clean)
+            if self.on_job:
+                await self.on_job(job)
+            return
+        if msg.get("method") == "mining.set_target":
+            # Some pools retarget without a fresh notify; surface as a job-less event.
+            log.info("pool set_target: %r", msg.get("params"))
+            return
+        req_id = msg.get("id")
+        fut = self._pending.get(req_id)
+        if fut is not None and not fut.done():
+            if msg.get("error"):
+                fut.set_exception(StratumError(msg["error"]))
+            else:
+                fut.set_result(msg.get("result"))
+        elif msg.get("method"):
+            log.debug("ignoring server method %s", msg["method"])
+
+    def _parse_notify(self, params) -> Job:
+        if isinstance(params, dict):
+            return Job.from_notify(params)
+        if isinstance(params, list) and len(params) >= 7:
+            # alphapool positional: [job_id, prev_hash, header, 0, ntime, nbits, clean]
+            import struct as _struct
+
+            header = bytes.fromhex(params[2])
+            nbits = int(params[5], 16) if isinstance(params[5], str) else int(params[5])
+            from .targets import nbits_to_difficulty
+
+            return Job(
+                job_id=str(params[0]),
+                header=header,
+                share_target=nbits_to_difficulty(nbits),
+                height=0,
+                clean=bool(params[6]),
+            )
+        raise ValueError("unrecognized mining.notify shape")
+
+    # -- shares ---------------------------------------------------------------
+
+    async def submit(self, job_id: str, plain_proof_b64: str, hashrate: float | None = None) -> SubmitResult:
+        if self.dialect == "positional":
+            params = [self.worker, job_id, plain_proof_b64]
+        else:
+            params = {"job_id": job_id, "plain_proof": plain_proof_b64}
+            if hashrate is not None:
+                params["hs"] = round(hashrate, 2)
+        t0 = time.monotonic()
+        try:
+            result = await self._call("mining.submit", params)
+        except StratumError as exc:
+            code = exc.code
+            label = {STALE_SHARE_CODE: "stale", LOW_DIFF_CODE: "low difficulty"}.get(code, "rejected")
+            log.warning("share REJECTED (%s): %s", label, exc)
+            return SubmitResult(False, code, str(exc))
+        log.info("share accepted in %.0f ms", (time.monotonic() - t0) * 1e3)
+        return SubmitResult(bool(result))
+
+
+class StratumError(Exception):
+    def __init__(self, error) -> None:
+        code, message = None, str(error)
+        if isinstance(error, list) and len(error) >= 2:
+            code, message = error[0], str(error[1])
+        super().__init__(message)
+        self.code = code

--- a/meowminer/src/meowminer/targets.py
+++ b/meowminer/src/meowminer/targets.py
@@ -1,0 +1,91 @@
+"""Target / difficulty math for Pearlhash pool mining.
+
+Mirrors the consensus math in the Pearl repo (zk-pow) and P2Pearl exactly:
+
+* ``nbits_to_difficulty``  — zk-pow/src/api/proof_utils.rs::nbits_to_difficulty
+* ``target_to_bits``       — P2Pearl/src/p2pearl/consensus/difficulty.py::target_to_bits
+* ``share_bound``          — zk-pow/src/api/sanity_checks.rs::extract_difficulty_bound
+
+The subtlety that costs you shares if you get it wrong: pools grade a submitted
+plain proof with ``verify_plain_proof_with_nbits(header, proof, share_nbits)``.
+The Rust verifier decodes the compact nbits and then multiplies by the
+difficulty-adjustment factor ``h * w * k`` (tile height x tile width x common
+dim).  A miner must therefore grade candidates locally against
+
+    bound = nbits_to_difficulty(target_to_bits(share_target)) * h * w * k
+
+NOT against the raw 256-bit ``target`` field from ``mining.notify`` — grading at
+the raw target is ~2**19 times too strict and silently discards almost every
+share the pool would have paid you for.
+
+``hash_jackpot`` is compared as a LITTLE-endian 256-bit integer.
+"""
+
+from __future__ import annotations
+
+U256_MAX = (1 << 256) - 1
+
+
+def nbits_to_difficulty(nbits: int) -> int:
+    """Decode Bitcoin-compact nbits to a 256-bit integer target.
+
+    Returns 0 for invalid encodings (zero mantissa/exponent or sign bit set),
+    matching the Rust implementation.
+    """
+    exponent = (nbits >> 24) & 0xFF
+    mantissa = nbits & 0x00FFFFFF
+    if mantissa == 0 or exponent == 0:
+        return 0
+    if mantissa & 0x00800000:
+        return 0  # sign bit set -> invalid
+    if exponent <= 3:
+        target = mantissa >> (8 * (3 - exponent))
+    else:
+        target = mantissa << (8 * (exponent - 3))
+    return target & U256_MAX
+
+
+def target_to_bits(target: int) -> int:
+    """Encode a 256-bit integer target as Bitcoin-compact nbits."""
+    if target <= 0:
+        return 0
+    nbytes = (target.bit_length() + 7) // 8
+    if nbytes <= 3:
+        mantissa = target << (8 * (3 - nbytes))
+    else:
+        mantissa = target >> (8 * (nbytes - 3))
+    if mantissa & 0x00800000:
+        mantissa >>= 8
+        nbytes += 1
+    return (nbytes << 24) | (mantissa & 0x007FFFFF)
+
+
+def share_bound(share_target: int, tile_h: int, tile_w: int, common_dim: int) -> int:
+    """The bound the pool will actually grade our shares at.
+
+    Round-trips the 256-bit share target through compact nbits (losing the same
+    precision the pool's verifier loses) and applies the h*w*k adjustment, so
+    local grading is bit-identical to pool-side acceptance.
+    """
+    nbits = target_to_bits(share_target)
+    return nbits_to_difficulty(nbits) * tile_h * tile_w * common_dim
+
+
+def block_bound(header_nbits: int, tile_h: int, tile_w: int, common_dim: int) -> int:
+    """The bound for an actual block solution (the header's own nbits)."""
+    return nbits_to_difficulty(header_nbits) * tile_h * tile_w * common_dim
+
+
+def meets_bound(hash_jackpot_le: bytes, bound: int) -> bool:
+    """True iff U256_LE(hash_jackpot) <= bound (Pearl's nested-target check)."""
+    if len(hash_jackpot_le) != 32:
+        raise ValueError("hash_jackpot must be 32 bytes")
+    return int.from_bytes(hash_jackpot_le, "little") <= bound
+
+
+def parse_notify_target(target_hex: str) -> int:
+    """Parse the 64-char big-endian hex ``target`` field of mining.notify."""
+    t = target_hex.strip().lower().removeprefix("0x")
+    if len(t) != 64:
+        raise ValueError(f"target must be 64 hex chars, got {len(t)}")
+    return int(t, 16)

--- a/meowminer/src/meowminer/vendor/PEARL-LICENSE
+++ b/meowminer/src/meowminer/vendor/PEARL-LICENSE
@@ -1,0 +1,29 @@
+ISC License
+
+Copyright (c) 2025-2026 Pearl Research Labs
+Copyright (c) 2015-2016 The Decred developers
+
+Permission to use, copy, modify, and distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+---
+
+This monorepo contains multiple sub-projects, each with its own LICENSE
+file. See the LICENSE in each sub-directory for details:
+
+  node/             ISC                (Pearl Research Labs)
+  wallet/           ISC                (Pearl Research Labs)
+  spv/              MIT                (Lightning Labs)
+  dnsseeder/        Apache-2.0
+  plonky2/          MIT OR Apache-2.0  (The Plonky2 Authors, Pearl Research Labs)
+  xmss/external/    CC0-1.0
+  miner/pearl-gemm/third_party/cutlass/  BSD-3-Clause (NVIDIA)

--- a/meowminer/src/meowminer/vendor/noise_generation.py
+++ b/meowminer/src/meowminer/vendor/noise_generation.py
@@ -1,0 +1,193 @@
+# Vendored unmodified from pearl-research-labs/pearl
+# (miner/miner-base/src/miner_base/noise_generation.py, ISC license -- see
+# PEARL-LICENSE in this directory), except this import header: the upstream
+# `miner_utils.get_logger` is replaced with stdlib logging so the file has no
+# dependency on the pearl uv workspace. The noise must be bit-identical to the
+# reference or every share is rejected; do not "clean up" this file.
+import logging
+from math import ceil
+
+import numpy as np
+import torch
+from blake3 import blake3
+
+logger = logging.getLogger(__name__)
+
+
+def is_power_of_two(n: int) -> bool:
+    return n != 0 and (n & (n - 1)) == 0
+
+
+def num_to_bytes(n: int) -> bytes:
+    byte_length = (n.bit_length() + 7) // 8
+    return n.to_bytes(byte_length, "big")
+
+
+def np_mul_hi_u32(a: np.uint32, b: np.uint32):
+    prod64 = a.astype(np.uint64) * b.astype(np.uint64)
+    return (prod64 >> np.uint64(32)).astype(np.uint32)
+
+
+class NoiseGenerator:
+    """A class for generating noise for a given tensor."""
+
+    def __init__(self, noise_rank: int = 128, noise_range: int = 128):
+        self.noise_rank = noise_rank
+
+        if not is_power_of_two(noise_range):
+            raise ValueError("noise_range must be a power of two")
+
+        if not is_power_of_two(noise_rank):
+            raise ValueError("noise_rank must be a power of two")
+
+        if noise_range > 128:
+            raise ValueError("noise_range must fit in uint7")
+
+        if noise_rank % blake3.digest_size != 0:
+            raise ValueError(f"noise_rank must be divisible by {blake3.digest_size=}")
+
+        logger.info(
+            f"Initialized NoiseGenerator with noise_rank={noise_rank}, noise_range={noise_range}"
+        )
+
+        # noise_range is a power of two, so we can use a mask to get the lower bits
+        idxs_per_col = 2
+        _noise_range = noise_range // idxs_per_col
+        self.zero_point_translation = _noise_range // 2
+        self.range_mask = _noise_range - 1
+        self.rank_mask = self.noise_rank - 1
+
+    def generate_noise_metrices(
+        self,
+        key_A: bytes,
+        key_B: bytes,
+        A_rows: int,
+        common_dim: int,
+        B_cols: int,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        if A_rows < self.noise_rank:
+            raise ValueError(f"A_rows must be greater than or equal to noise_rank, got {A_rows}")
+        if common_dim < self.noise_rank:
+            raise ValueError(
+                f"common_dim must be greater than or equal to noise_rank, got {common_dim}"
+            )
+        if B_cols < self.noise_rank:
+            raise ValueError(f"B_cols must be greater than or equal to noise_rank, got {B_cols}")
+
+        seed_A = (
+            torch.frombuffer(bytearray(b"A_tensor" + b"\x00" * 24), dtype=torch.uint8)
+            .numpy()
+            .tobytes()
+        )
+        seed_B = (
+            torch.frombuffer(bytearray(b"B_tensor" + b"\x00" * 24), dtype=torch.uint8)
+            .numpy()
+            .tobytes()
+        )
+
+        A_L = self.__generate_uniform_random_matrix(seed_A, key_A, A_rows)
+        A_R = self.__generate_permutation_matrix(
+            seed_A,
+            key_A,
+            self.noise_rank,
+            common_dim,
+            assign_columns=True,
+        )
+        B_L = self.__generate_permutation_matrix(
+            seed_B,
+            key_B,
+            common_dim,
+            self.noise_rank,
+            assign_columns=False,
+        )
+        B_R = self.__generate_uniform_random_matrix(seed_B, key_B, B_cols).T
+
+        return A_L, A_R, B_L, B_R
+
+    def __get_random_hash(self, index: int, seed: bytes, key: bytes, prepend_index: int) -> bytes:
+        message_prepend = np.zeros(8, dtype=np.int32)
+        message_prepend[prepend_index] = 1 + index
+        message_bytes = message_prepend.tobytes() + seed
+        return blake3(message_bytes, key=key).digest()
+
+    def __generate_uniform_random_matrix(
+        self,
+        seed: bytes,
+        key: bytes,
+        rows: int,
+    ) -> torch.Tensor:
+        """Generate a uniform random matrix."""
+
+        cols = self.noise_rank
+        assert len(seed) == 32, "seed must be 32 bytes"
+        assert len(key) == 32, "key must be 32 bytes"
+        noise_matrix = torch.zeros(rows, cols, dtype=torch.int8)
+
+        draws = int(ceil(rows * cols / blake3.digest_size))
+
+        # draw all required hashes
+        random_bytes = b"".join(self.__get_random_hash(i, seed, key, 0) for i in range(draws))
+
+        # Convert to tensor and apply operations in one go
+        random_tensor = torch.frombuffer(bytearray(random_bytes), dtype=torch.uint8)[: rows * cols]
+
+        # Vectorized mask, translation, and reshape
+        noise_matrix = (
+            ((random_tensor & self.range_mask) - self.zero_point_translation)
+            .to(torch.int8)
+            .view(rows, cols)
+        )
+
+        return noise_matrix
+
+    def __generate_permutation_matrix(
+        self,
+        seed: bytes,
+        key: bytes,
+        rows: int,
+        cols: int,
+        assign_columns: bool,
+    ) -> torch.Tensor:
+        """Generate a permutation matrix."""
+        assert (rows == self.noise_rank) or (cols == self.noise_rank), (
+            "rows or cols must be equal to noise_rank"
+        )
+        assert len(seed) == 32, "seed must be 32 bytes"
+        assert len(key) == 32, "key must be 32 bytes"
+        noise_matrix = torch.zeros(rows, cols, dtype=torch.int8)
+
+        if assign_columns:
+            required_lines = cols
+            assert rows == self.noise_rank, "rows must be equal to noise_rank"
+        else:
+            required_lines = rows
+            assert cols == self.noise_rank, "cols must be equal to noise_rank"
+
+        bytes_per_lines = 4
+        draws = int(ceil(required_lines * bytes_per_lines / blake3.digest_size))
+
+        # We draw 4 bytes for each matrix element
+        for i in range(draws):
+            random_hash = self.__get_random_hash(i, seed, key, 1)
+            random_uint32_array = np.frombuffer(
+                random_hash,
+                dtype=np.uint32,
+            )
+            for k in range(blake3.digest_size // bytes_per_lines):
+                random_uint32 = random_uint32_array[k]
+                first_idx = random_uint32 & self.rank_mask
+                second_idx = first_idx ^ (
+                    1 + np_mul_hi_u32(np.uint32(self.noise_rank - 1), random_uint32)
+                )
+                permutation = torch.zeros(self.noise_rank, dtype=torch.int8)
+                permutation[first_idx] = 1
+                permutation[second_idx] = -1
+                assignment_index = i * blake3.digest_size // bytes_per_lines + k
+                if assignment_index >= required_lines:
+                    break
+                if assign_columns:
+                    noise_matrix[:, assignment_index] = permutation
+                else:
+                    noise_matrix[assignment_index, :] = permutation
+
+        return noise_matrix

--- a/meowminer/tests/test_algo.py
+++ b/meowminer/tests/test_algo.py
@@ -1,0 +1,108 @@
+"""Algorithm primitives vs a direct transcription of zk-pow's scalar reference.
+
+The scalar implementation below is a line-by-line port of
+zk-pow/src/ffi/mine.rs::try_mine_one's jackpot loop; the vectorized
+meowminer.algo.jackpots_for_attempt must match it bit-for-bit.
+"""
+
+import sys
+from pathlib import Path
+
+import numpy as np
+from blake3 import blake3
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from meowminer.algo import (
+    JACKPOT_SIZE,
+    LROT_PER_TILE,
+    MiningConfig,
+    PeriodicPattern,
+    compute_commitment_seeds,
+    compute_jackpot_hash,
+    compute_job_key,
+    jackpots_for_attempt,
+    pad_to_chunk_boundary,
+)
+
+
+def scalar_jackpot(a_noised, bt_noised, a_rows, b_cols, rank, k):
+    """Direct port of the rust loop (i32 wrapping arithmetic)."""
+    h, w = len(a_rows), len(b_cols)
+    tile = [[0] * w for _ in range(h)]
+    jackpot = [0] * JACKPOT_SIZE
+    for ll in range(rank, k + 1, rank):
+        for u, ai in enumerate(a_rows):
+            for v, bi in enumerate(b_cols):
+                acc = tile[u][v]
+                for l in range(ll - rank, ll):
+                    acc = (acc + int(a_noised[ai][l]) * int(bt_noised[bi][l])) & 0xFFFFFFFF
+                tile[u][v] = acc
+        xored = 0
+        for row in tile:
+            for x in row:
+                xored ^= x
+        tid = (ll // rank - 1) % JACKPOT_SIZE
+        j = jackpot[tid]
+        jackpot[tid] = (((j << LROT_PER_TILE) | (j >> (32 - LROT_PER_TILE))) & 0xFFFFFFFF) ^ xored
+    return jackpot
+
+
+def small_config():
+    # tiny: tile 2x2, rank 32, k 64. Canonical shape for the index list {0,1}
+    # (PeriodicPattern::from_list pads with (period, 1) tuples, period = 2).
+    rows = PeriodicPattern(shape=((1, 2), (2, 1), (2, 1)))
+    cols = PeriodicPattern(shape=((1, 2), (2, 1), (2, 1)))
+    return MiningConfig(common_dim=64, rank=32, rows_pattern=rows, cols_pattern=cols, config_bytes=b"\x00" * 52)
+
+
+def test_pattern_helpers():
+    p = PeriodicPattern(shape=((1, 2), (2, 1), (2, 1)))
+    assert p.to_list() == [0, 1]
+    assert p.period == 2
+    assert p.size == 2
+    # consecutive-pair tiles exactly cover the dimension
+    assert p.partitions(8) == [[0, 1], [2, 3], [4, 5], [6, 7]]
+    assert p.valid_offsets(8) == [0, 2, 4, 6]
+
+
+def test_vectorized_jackpots_match_scalar_reference():
+    rng = np.random.default_rng(7)
+    cfg = small_config()
+    m = n = 8
+    a_noised = rng.integers(-127, 128, size=(m, cfg.common_dim), dtype=np.int32)
+    bt_noised = rng.integers(-127, 128, size=(n, cfg.common_dim), dtype=np.int32)
+
+    jackpots, parts = jackpots_for_attempt(a_noised, bt_noised, cfg)
+    assert len(parts) == 16  # 4 row partitions x 4 col partitions
+    for i, (a_rows, b_cols) in enumerate(parts):
+        expected = scalar_jackpot(a_noised, bt_noised, a_rows, b_cols, cfg.rank, cfg.common_dim)
+        assert jackpots[i].tolist() == expected, f"partition {i} ({a_rows}x{b_cols})"
+
+
+def test_jackpot_hash_is_keyed_blake3_of_le_words():
+    j = np.arange(16, dtype=np.uint32)
+    seed = bytes(range(32))
+    expected = blake3(b"".join(int(x).to_bytes(4, "little") for x in j), key=seed).digest()
+    assert compute_jackpot_hash(j, seed) == expected
+
+
+def test_commitment_seed_chain():
+    job_key = blake3(b"header" + b"config").digest()
+    a = pad_to_chunk_boundary(b"\x01" * 100)
+    b = pad_to_chunk_boundary(b"\x02" * 100)
+    b_seed, a_seed = compute_commitment_seeds(job_key, a, b)
+    hash_a = blake3(a, key=job_key).digest()
+    hash_b = blake3(b, key=job_key).digest()
+    assert b_seed == blake3(job_key + hash_b).digest()
+    assert a_seed == blake3(b_seed + hash_a).digest()
+
+
+def test_pad_to_chunk_boundary():
+    assert len(pad_to_chunk_boundary(b"x" * 1024)) == 1024
+    assert len(pad_to_chunk_boundary(b"x" * 1025)) == 2048
+    assert pad_to_chunk_boundary(b"") == b""
+
+
+def test_job_key():
+    assert compute_job_key(b"h", b"c") == blake3(b"hc").digest()

--- a/meowminer/tests/test_cross_engine.py
+++ b/meowminer/tests/test_cross_engine.py
@@ -1,0 +1,81 @@
+"""Gold-standard test: shares mined by meowminer engines must be accepted by
+the actual Rust reference verifier (pearl_mining.verify_plain_proof).
+
+Requires the pearl_mining wheel (and torch for the torch engine test); both
+tests are skipped when the native deps are absent so the rest of the suite
+stays runnable anywhere. Run on Python >= 3.12.
+
+Validated constraints discovered against the verifier (2026-06-09):
+  * k must be >= 16 * rank        ("k must be >= 16r")
+  * tile h*w must be >= 32        ("Inner hash size must be >= 32")
+  * MMAType on the network: Int7xInt7ToInt32
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+pm = pytest.importorskip("pearl_mining")
+
+from meowminer.algo import MiningConfig, PeriodicPattern, compute_job_key  # noqa: E402
+from meowminer.job import Job  # noqa: E402
+from meowminer.proofs import build_plain_proof_b64  # noqa: E402
+from meowminer.targets import nbits_to_difficulty  # noqa: E402
+
+EASY_NBITS = 0x207FFFFF  # regtest-style: every attempt clears the bound
+
+
+def make_fixture():
+    rows = pm.PeriodicPattern.from_list(list(range(8)))  # 8x8 tile (>= 32 elems)
+    cfg_pm = pm.MiningConfiguration(
+        2048, 128, pm.MMAType.Int7xInt7ToInt32, rows, rows, bytes(pm.MiningConfiguration.RESERVED)
+    )
+    header_bytes = (
+        bytes([1, 0, 0, 0]) + bytes(32) + bytes(32)
+        + (0x66666666).to_bytes(4, "little") + EASY_NBITS.to_bytes(4, "little")
+    )
+    my_cfg = MiningConfig(
+        common_dim=2048,
+        rank=128,
+        rows_pattern=PeriodicPattern(shape=tuple((int(s), int(l)) for s, l in rows.shape)),
+        cols_pattern=PeriodicPattern(shape=tuple((int(s), int(l)) for s, l in rows.shape)),
+        config_bytes=bytes(cfg_pm.to_bytes()),
+    )
+    job = Job(job_id="t", header=header_bytes, share_target=nbits_to_difficulty(EASY_NBITS), height=1)
+    return header_bytes, my_cfg, job
+
+
+def mine_one_and_verify(engine, my_cfg, job, header_bytes):
+    bound = job.block_bound(my_cfg.tile_h, my_cfg.tile_w, my_cfg.dot_product_length)
+    for hits, stats in engine.mine(job, bound, bound):
+        assert stats.partitions == 256
+        assert hits, "easy bound must hit on every partition"
+        hit = hits[0]
+        b64 = build_plain_proof_b64(hit, my_cfg, compute_job_key(header_bytes, my_cfg.config_bytes))
+        header = pm.IncompleteBlockHeader.from_bytes(header_bytes)
+        ok, msg = pm.verify_plain_proof(header, pm.PlainProof.from_base64(b64))
+        assert ok, f"reference verifier rejected the share: {msg}"
+        return
+
+
+def test_cpu_engine_share_accepted_by_reference_verifier():
+    pytest.importorskip("torch")  # vendored noise generator needs it
+    from meowminer.engines.cpu import CpuEngine
+
+    header_bytes, my_cfg, job = make_fixture()
+    eng = CpuEngine(seed=1234)
+    eng.configure(my_cfg, 128, 128)
+    mine_one_and_verify(eng, my_cfg, job, header_bytes)
+
+
+def test_torch_engine_share_accepted_by_reference_verifier():
+    pytest.importorskip("torch")
+    from meowminer.engines.torch_int8 import TorchInt8Engine
+
+    header_bytes, my_cfg, job = make_fixture()
+    eng = TorchInt8Engine(device="cpu", m=128, n=128)
+    eng.configure(my_cfg)
+    mine_one_and_verify(eng, my_cfg, job, header_bytes)

--- a/meowminer/tests/test_stratum.py
+++ b/meowminer/tests/test_stratum.py
@@ -1,0 +1,100 @@
+"""Stratum client against an in-process pool speaking the P2Pearl object dialect."""
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from meowminer.job import Job
+from meowminer.stratum import StratumClient
+
+HEADER_HEX = ("01000000" + "11" * 32 + "22" * 32 + "66666666" + "ffff7f20")
+TARGET_HEX = "0000000000000000000000000000000000000000000000000000000000010000"
+
+
+class FakePool:
+    def __init__(self):
+        self.received = []
+        self.server = None
+        self.port = None
+        self.accept_shares = True
+
+    async def start(self):
+        self.server = await asyncio.start_server(self._handle, "127.0.0.1", 0)
+        self.port = self.server.sockets[0].getsockname()[1]
+
+    async def _handle(self, reader, writer):
+        async def send(obj):
+            writer.write((json.dumps(obj, separators=(",", ":")) + "\n").encode())
+            await writer.drain()
+
+        while True:
+            line = await reader.readline()
+            if not line:
+                return
+            msg = json.loads(line)
+            self.received.append(msg)
+            method = msg.get("method")
+            if method == "mining.authorize":
+                await send({"id": msg["id"], "result": True})
+                await send({
+                    "id": None,
+                    "method": "mining.notify",
+                    "params": {"job_id": "2a-1", "header": HEADER_HEX, "target": TARGET_HEX, "height": 42},
+                })
+            elif method == "mining.submit":
+                if self.accept_shares:
+                    await send({"id": msg["id"], "result": True})
+                else:
+                    await send({"id": msg["id"], "result": None, "error": [23, "low difficulty share", None]})
+            else:
+                await send({"id": msg.get("id"), "result": True})
+
+
+def test_object_dialect_end_to_end():
+    async def scenario():
+        pool = FakePool()
+        await pool.start()
+
+        jobs: list[Job] = []
+        got_job = asyncio.Event()
+
+        client = StratumClient("127.0.0.1", pool.port, wallet="prl1ptest", worker="rigtest")
+
+        async def on_job(job: Job):
+            jobs.append(job)
+            got_job.set()
+
+        client.on_job = on_job
+        await client.connect()
+        await asyncio.wait_for(got_job.wait(), 5)
+
+        job = jobs[0]
+        assert job.job_id == "2a-1"
+        assert job.height == 42
+        assert job.share_target == 0x10000
+        assert len(job.header) == 76
+        assert job.nbits == 0x207FFFFF  # LE bytes ffff7f20
+        assert job.timestamp == 0x66666666
+
+        ok = await client.submit("2a-1", "cHJvb2Y=", hashrate=123.0)
+        assert ok.accepted
+
+        pool.accept_shares = False
+        bad = await client.submit("2a-1", "cHJvb2Y=")
+        assert not bad.accepted
+        assert bad.error_code == 23
+
+        auth = pool.received[0]
+        assert auth["method"] == "mining.authorize"
+        assert auth["params"] == {"wallet": "prl1ptest", "worker": "rigtest", "agent": "meowminer/0.1.0"}
+        submit = next(r for r in pool.received if r.get("method") == "mining.submit")
+        assert submit["params"]["job_id"] == "2a-1"
+        assert submit["params"]["plain_proof"] == "cHJvb2Y="
+        assert submit["params"]["hs"] == 123.0
+
+        await client.close()
+
+    asyncio.run(scenario())

--- a/meowminer/tests/test_targets.py
+++ b/meowminer/tests/test_targets.py
@@ -1,0 +1,75 @@
+"""Target math vectors, cross-checked against P2Pearl/zk-pow semantics."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from meowminer.targets import (
+    meets_bound,
+    nbits_to_difficulty,
+    parse_notify_target,
+    share_bound,
+    target_to_bits,
+)
+
+
+def test_nbits_roundtrip_genesis_style():
+    # 0x207fffff: classic max-target regtest nbits
+    t = nbits_to_difficulty(0x207FFFFF)
+    assert t == 0x7FFFFF << (8 * (0x20 - 3))
+    assert target_to_bits(t) == 0x207FFFFF
+
+
+def test_nbits_invalid_encodings():
+    assert nbits_to_difficulty(0) == 0
+    assert nbits_to_difficulty(0x00FFFFFF) == 0  # zero exponent
+    assert nbits_to_difficulty(0x20800000) == 0  # sign bit set
+    assert nbits_to_difficulty(0x01000000) == 0  # zero mantissa
+
+
+def test_nbits_small_exponents():
+    # exponent <= 3 shifts the 3-byte mantissa right by 8*(3-exponent)
+    assert nbits_to_difficulty(0x01120000) == 0x120000 >> 16  # 0x12
+    assert nbits_to_difficulty(0x02123400) == 0x123400 >> 8  # 0x1234
+    assert nbits_to_difficulty(0x03123456) == 0x123456
+    assert nbits_to_difficulty(0x04123456) == 0x123456 << 8
+
+
+def test_target_to_bits_sign_bit_normalization():
+    # A target whose top mantissa byte has the high bit set must be renormalized
+    t = 0x80FFFF << 8
+    nbits = target_to_bits(t)
+    assert not (nbits & 0x00800000)
+    # round-trips within compact precision
+    assert target_to_bits(nbits_to_difficulty(nbits)) == nbits
+
+
+def test_share_bound_applies_hwk_adjustment():
+    target = 1 << 200
+    h, w, k = 16, 16, 4096
+    b = share_bound(target, h, w, k)
+    base = nbits_to_difficulty(target_to_bits(target))
+    assert b == base * h * w * k
+    assert b > target  # the adjustment makes the bound ~2**20 easier
+
+
+def test_meets_bound_little_endian():
+    # hash bytes are compared as a LITTLE-endian integer
+    h = bytes([1] + [0] * 31)  # LE value 1
+    assert meets_bound(h, 1)
+    assert not meets_bound(h, 0)
+    h2 = bytes([0] * 31 + [1])  # LE value 2**248
+    assert not meets_bound(h2, 1 << 247)
+    assert meets_bound(h2, 1 << 248)
+
+
+def test_parse_notify_target():
+    assert parse_notify_target("00" * 31 + "ff") == 0xFF
+    assert parse_notify_target(("0" * 63) + "1") == 1
+    try:
+        parse_notify_target("ff")
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("short target must raise")


### PR DESCRIPTION
Initial implementation of the miner planned in Meowcoin-Foundation/MeowMiner
(intended to be moved there; see meowminer/HANDOFF.md):

- Pearlhash stratum client (herominers/luckypool object dialect + alphapool
  positional fallback)
- Target math incl. the h*w*k verifier adjustment, jackpot pipeline bit-exact
  vs zk-pow's reference, vendored deterministic noise generator (ISC)
- CPU reference engine and torch tensor-core int8 GPU engine; shares from
  both are accepted by pearl_mining's Rust verify_plain_proof (gold test)
- Share packaging + pre-submit local verification via pearl_mining PyO3
- Mfarm/CatStack integration (registry patch, herominers flight sheets,
  SRBMiner A/B protocol) and CI workflow for the MeowMiner repo

https://claude.ai/code/session_01DTCrgopaTcsKis76KseaEH